### PR TITLE
hw1

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,28 @@
 version: "3.3"
 
 services:
+  popug-acc:
+    build:
+      context: popug-acc/
+    image: pupug-acc:lates
+    container_name: auth
+    depends_on:
+      keycloak:
+        condition: service_healthy
+  popu-tracker:
+    build:
+      context: popu-tracker/
+    image: popu-tracker:latest
+    container_name: tracker
+    depends_on:
+      postgres:
+        condition:
+      popug-acc:
+        condition: service_started
+    links:
+      - postgres
+      - keycloak
+
   postgres:
     image: postgres:16.2
     container_name: postgres
@@ -15,3 +37,18 @@ services:
       - POSTGRES_DB=postgres
     ports:
       - "5432:5432"
+  keycloak:
+    image: quay.io/keycloak/keycloak:23.0.7
+    environment:
+      - KEYCLOAK_ADMIN=admin
+      - KEYCLOAK_ADMIN_PASSWORD=admin
+      - KC_HEALTH_ENABLED=true
+    healthcheck:
+      test: [ "CMD-SHELL", "exec 3<>/dev/tcp/127.0.0.1/8080;echo -e \"GET /health/ready HTTP/1.1\r\nhost: http://localhost\r\nConnection: close\r\n\r\n\" >&3;grep \"HTTP/1.1 200 OK\" <&3" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    ports:
+      - "7000:8080"
+    command:
+      - start-dev

--- a/popu-tracker/Dockerfile
+++ b/popu-tracker/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:21-slim
+WORKDIR /app
+COPY popu-tracker/target/scala-2.13/popug-tracker-*.jar ./app.jar
+ENTRYPOINT ["java"]

--- a/popu-tracker/docker-compose.yaml
+++ b/popu-tracker/docker-compose.yaml
@@ -1,0 +1,24 @@
+version: "3.3"
+
+services:
+  popu-tracker:
+    build: .
+    image: popu-tracker:latest
+    container_name: popu-tracker
+    depends_on:
+      postgres:
+        condition: service_healthy
+  postgres:
+    image: postgres:16.2
+    container_name: popu-tracker-postgres
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready", "-U", "postgres", "-d", "postgres" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=postgres
+    ports:
+      - "15432:5432"

--- a/popu-tracker/src/main/resources/db/migration/V1__init_account_store.sql
+++ b/popu-tracker/src/main/resources/db/migration/V1__init_account_store.sql
@@ -1,0 +1,6 @@
+create table if not exists account_store(
+entity_id uuid primary key,
+entity_version integer default 1,
+full_name varchar,
+role varchar not null
+);

--- a/popu-tracker/src/main/resources/db/migration/V2__init_task_store.sql
+++ b/popu-tracker/src/main/resources/db/migration/V2__init_task_store.sql
@@ -1,0 +1,8 @@
+create table if not exists task_store(
+entity_id uuid primary key,
+entity_version integer default 1,
+created_at timestamp,
+title varchar,
+assigned_on uuid not null,
+status boolean default false
+);

--- a/popu-tracker/src/main/resources/db/migration/V3__init_offset_data_store.sql
+++ b/popu-tracker/src/main/resources/db/migration/V3__init_offset_data_store.sql
@@ -1,0 +1,6 @@
+create table if not exists offset_data(
+    "id" serial primary key,
+    "topic" varchar not null,
+    "partition" int not null,
+    "offset" int8 not null
+);

--- a/popu-tracker/src/main/resources/db/migration/V4__init_entity_logs_store.sql
+++ b/popu-tracker/src/main/resources/db/migration/V4__init_entity_logs_store.sql
@@ -1,0 +1,8 @@
+create table if not exists entity_logs(
+    "id" serial primary key,
+    "message" varchar,
+    "uuid" uuid,
+    "date" timestamp,
+    "level" int,
+    "class" varchar
+);

--- a/popu-tracker/src/main/scala/application/Application.scala
+++ b/popu-tracker/src/main/scala/application/Application.scala
@@ -1,0 +1,30 @@
+package application
+
+import akka.actor.typed.scaladsl.AskPattern.{Askable, schedulerFromActorSystem}
+import akka.actor.typed.{ActorRef, ActorSystem, Props, SpawnProtocol}
+import akka.util.Timeout
+import application.supervisior.PopuTrackerSupervisor
+import application.supervisior.SystemSupervisor._
+import com.typesafe.config.{Config, ConfigFactory}
+import slick.basic.DatabaseConfig
+import slick.jdbc.PostgresProfile
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.ExecutionContextExecutor
+
+object Application extends App {
+  implicit val system: ActorSystem[SpawnProtocol.Command] =
+    ActorSystem[SpawnProtocol.Command](SpawnProtocol(), "supervisor")
+
+  implicit val exec: ExecutionContextExecutor = system.executionContext
+  implicit val timeout: Timeout = Timeout(10, TimeUnit.SECONDS)
+
+  val config: Config = ConfigFactory.load()
+  val dbConfig: DatabaseConfig[PostgresProfile] = DatabaseConfig.forConfig("postgres", config)
+
+  private val supervisor = system ? { ref: ActorRef[ActorRef[Message]] =>
+    SpawnProtocol.Spawn(PopuTrackerSupervisor(config, dbConfig), "popu-tracker-supervisor", Props.empty, ref)
+  }
+
+  supervisor.flatMap(_ ? [Message] { replyTo => Init(replyTo) })
+}

--- a/popu-tracker/src/main/scala/application/ecst/EcstConsumers.scala
+++ b/popu-tracker/src/main/scala/application/ecst/EcstConsumers.scala
@@ -1,0 +1,26 @@
+package application.ecst
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.kafka.scaladsl.Consumer
+import com.typesafe.config.Config
+import infrastructure.db.ecst.AccountSlickStore
+import infrastructure.kafka.AccountEcstConsumer
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.Future
+
+object EcstConsumers {
+  def startAll(
+                accountStore: AccountSlickStore
+              )(implicit sys: ActorSystem[_]): Future[Seq[Consumer.DrainingControl[Done]]] = {
+    val logger = LoggerFactory.getLogger("EcstConsumers")
+    val config = sys.settings.config.getConfig("akka.kafka")
+    val topicConfig = config.getConfig("topics")
+    val consumerConfig: Config = config.getConfig("consumer")
+
+    val accountTopic = topicConfig.getString("account")
+
+    AccountEcstConsumer(accountTopic, consumerConfig, accountStore)
+  }
+}

--- a/popu-tracker/src/main/scala/application/migration/PostgresMigration.scala
+++ b/popu-tracker/src/main/scala/application/migration/PostgresMigration.scala
@@ -1,0 +1,16 @@
+package application.migration
+
+import org.flywaydb.core.Flyway
+
+import javax.sql.DataSource
+
+object PostgresMigration {
+  def migrate(ds: DataSource): Unit = {
+    Flyway.configure()
+      .dataSource(ds)
+      .loggers("slf4j")
+      .baselineOnMigrate(true)
+      .load()
+      .migrate()
+  }
+}

--- a/popu-tracker/src/main/scala/application/supervisior/PopuTrackerSupervisor.scala
+++ b/popu-tracker/src/main/scala/application/supervisior/PopuTrackerSupervisor.scala
@@ -1,0 +1,68 @@
+package application.supervisior
+
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.{ActorRef, ActorSystem, Behavior}
+import akka.http.scaladsl.server.Route
+import akka.util.Timeout
+import application.ecst.EcstConsumers
+import application.migration.PostgresMigration
+import application.supervisior.SystemSupervisor.{InitSucceed, Message}
+import com.typesafe.config.Config
+import infrastructure.rest.utils.JWTUtils
+import infrastructure.rest.{RestEndpoint, Routes}
+import slick.basic.DatabaseConfig
+import slick.jdbc.PostgresProfile
+import slick.jdbc.PostgresProfile.api._
+import slick.jdbc.hikaricp.HikariCPJdbcDataSource
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.ExecutionContextExecutor
+
+object PopuTrackerSupervisor extends SystemSupervisor {
+  override protected def init(
+                               config: Config,
+                               dbConfig: DatabaseConfig[PostgresProfile]
+                             )(replyTo: ActorRef[Message]): Behavior[Message] = {
+    Behaviors.setup[Message] { implicit context =>
+      implicit val ec: ExecutionContextExecutor = context.executionContext
+      implicit val system: ActorSystem[_] = context.system
+      implicit val dc: DatabaseConfig[PostgresProfile] = dbConfig
+      implicit val jwtUtils: JWTUtils = new JWTUtils(config.getConfig("jwt"))
+      implicit val timeout: Timeout = Timeout(10, TimeUnit.SECONDS)
+
+     if (config.getBoolean("migrations-enabled")) {
+        PostgresMigration.migrate(dbConfig.db.source.asInstanceOf[HikariCPJdbcDataSource].ds)
+      }
+
+      val offsets = TableQuery[OffsetDataTable]
+      val logs = TableQuery[DbEntityLogDataTable]
+
+      lazy val accStore = AccountSlickStore(dbConfig.db, offsets, logs)
+
+      val isKafkaEnabled = config.getConfig("kafka").getBoolean("enable")
+
+      if (isKafkaEnabled) {
+        EcstConsumers.startAll(accStore)
+        EcstProducers.startAll
+      }
+
+      val restConfig = config.getConfig("akka.http.server")
+      val host = restConfig.getString("host")
+      val port = restConfig.getInt("port")
+
+      val routes: Route = Routes()
+
+      context.spawn(
+        RestEndpoint(
+          host,
+          port,
+          routes
+        ), "rest-endpoint")
+
+      context.log.info("PopuTracker is started")
+
+      replyTo ! InitSucceed
+      Behaviors.same
+    }
+  }
+}

--- a/popu-tracker/src/main/scala/application/supervisior/SystemSupervisor.scala
+++ b/popu-tracker/src/main/scala/application/supervisior/SystemSupervisor.scala
@@ -1,0 +1,42 @@
+package application.supervisior
+
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.{ActorRef, Behavior}
+import application.supervisior.SystemSupervisor._
+import com.typesafe.config.Config
+import slick.basic.DatabaseConfig
+import slick.jdbc.PostgresProfile
+
+trait SystemSupervisor {
+  protected def init(
+                      config: Config,
+                      dbConfig: DatabaseConfig[PostgresProfile]
+                    )(replyTo: ActorRef[Message]): Behavior[Message]
+
+  protected def stop()(replyTo: ActorRef[Message]): Behavior[Message] = {
+    replyTo ! Stopped
+    Behaviors.stopped
+  }
+
+  def apply(
+             config: Config,
+             dbConfig: DatabaseConfig[PostgresProfile]
+           ): Behavior[Message] = {
+    Behaviors.receiveMessage {
+      case Init(replyTo) => init(config, dbConfig)(replyTo)
+      case Stop(replyTo) => stop()(replyTo)
+    }
+  }
+}
+
+object SystemSupervisor {
+  sealed trait Message
+
+  case class Init(replyTo: ActorRef[Message]) extends Message
+
+  case class Stop(replyTo: ActorRef[Message]) extends Message
+
+  case object InitSucceed extends Message
+
+  case object Stopped extends Message
+}

--- a/popu-tracker/src/main/scala/domain/Task.scala
+++ b/popu-tracker/src/main/scala/domain/Task.scala
@@ -1,0 +1,21 @@
+package domain
+
+import domain.value_object.{AccountId, TaskId}
+import spray.json.RootJsonFormat
+import spray.json.DefaultJsonProtocol._
+
+import java.time.Instant
+import domain.value_object.AccountId.accIdJsonFormat
+import infrastructure.rest._
+
+case class Task(
+               entityId: TaskId,
+               title: String,
+               createdAt: Instant,
+               assignedTo: AccountId,
+               isDone: Boolean
+               )
+
+object Task {
+  implicit val taskJsonFormat: RootJsonFormat[Task] = jsonFormat5(Task.apply)
+}

--- a/popu-tracker/src/main/scala/domain/value_object/Account.scala
+++ b/popu-tracker/src/main/scala/domain/value_object/Account.scala
@@ -1,0 +1,8 @@
+package domain.value_object
+
+case class Account(
+                  entityId: AccountId,
+                  entityVersion: EntityVersion,
+                  fullName: String,
+                  role: String
+                  ) extends BaseEntity[AccountId]

--- a/popu-tracker/src/main/scala/domain/value_object/AccountId.scala
+++ b/popu-tracker/src/main/scala/domain/value_object/AccountId.scala
@@ -1,0 +1,12 @@
+package domain.value_object
+
+import infrastructure.rest._
+import spray.json.RootJsonFormat
+import spray.json.DefaultJsonProtocol._
+import java.util.UUID
+
+case class AccountId(id: UUID) extends EntityId
+
+object AccountId extends EntityIdCompanion[AccountId] {
+  implicit val accIdJsonFormat: RootJsonFormat[AccountId] = jsonFormat1(AccountId.apply)
+}

--- a/popu-tracker/src/main/scala/domain/value_object/BaseEntity.scala
+++ b/popu-tracker/src/main/scala/domain/value_object/BaseEntity.scala
@@ -1,0 +1,8 @@
+package domain.value_object
+
+trait BaseEntity[Id <: EntityId] {
+
+  def entityId: Id
+
+  def entityVersion: EntityVersion
+}

--- a/popu-tracker/src/main/scala/domain/value_object/EntityId.scala
+++ b/popu-tracker/src/main/scala/domain/value_object/EntityId.scala
@@ -1,0 +1,13 @@
+package domain.value_object
+
+import java.util.UUID
+
+trait EntityId extends Any {
+  def id: UUID
+
+  override def toString: String = id.toString
+}
+
+object EntityId {
+  val NullId = new UUID(0x0ffffffffffffffffL, 0x0ffffffffffffffffL)
+}

--- a/popu-tracker/src/main/scala/domain/value_object/EntityIdCompanion.scala
+++ b/popu-tracker/src/main/scala/domain/value_object/EntityIdCompanion.scala
@@ -1,0 +1,13 @@
+package domain.value_object
+
+import java.util.UUID
+
+trait EntityIdCompanion[ID <: EntityId] {
+  implicit def companion: EntityIdCompanion[ID] = this
+
+  val NullObject: ID = apply(EntityId.NullId)
+
+  def fromString(str: String): ID = apply(UUID.fromString(str))
+
+  def apply(id: UUID): ID
+}

--- a/popu-tracker/src/main/scala/domain/value_object/EntityVersion.scala
+++ b/popu-tracker/src/main/scala/domain/value_object/EntityVersion.scala
@@ -1,0 +1,3 @@
+package domain.value_object
+
+case class EntityVersion(v: Int)

--- a/popu-tracker/src/main/scala/domain/value_object/TaskId.scala
+++ b/popu-tracker/src/main/scala/domain/value_object/TaskId.scala
@@ -1,0 +1,12 @@
+package domain.value_object
+
+import spray.json.DefaultJsonProtocol.jsonFormat1
+import spray.json.RootJsonFormat
+import infrastructure.rest._
+import java.util.UUID
+
+case class TaskId(id: UUID) extends EntityId
+
+object TaskId extends EntityIdCompanion[TaskId] {
+  implicit val taskIdJsonFormat: RootJsonFormat[TaskId] = jsonFormat1(TaskId.apply)
+}

--- a/popu-tracker/src/main/scala/infrastructure/db/ecst/AccountSlickStore.scala
+++ b/popu-tracker/src/main/scala/infrastructure/db/ecst/AccountSlickStore.scala
@@ -1,0 +1,6 @@
+package infrastructure.db.ecst
+
+// todo impl
+class AccountSlickStore {
+
+}

--- a/popu-tracker/src/main/scala/infrastructure/db/ecst/EcstOffsetStore.scala
+++ b/popu-tracker/src/main/scala/infrastructure/db/ecst/EcstOffsetStore.scala
@@ -1,0 +1,11 @@
+package infrastructure.db.ecst
+
+import akka.{Done, NotUsed}
+import domain.value_object.{BaseEntity, EntityId}
+
+import java.util.UUID
+import scala.concurrent.ExecutionContext
+
+abstract class EcstOffsetStore[Id <: EntityId, Entity <: BaseEntity[Id]](offsetProcessing: IOffsetProcessing)(implicit
+                                                                                                              ec: ExecutionContext)
+  extends OffsetStore[UUID, IEntityRecord[Id, Entity], Done, NotUsed](offsetProcessing)

--- a/popu-tracker/src/main/scala/infrastructure/db/ecst/IOffsetProcessing.scala
+++ b/popu-tracker/src/main/scala/infrastructure/db/ecst/IOffsetProcessing.scala
@@ -1,0 +1,22 @@
+package infrastructure.db.ecst
+
+import akka.Done
+
+import scala.concurrent.{ExecutionContext, Future}
+
+abstract class IOffsetProcessing {
+
+  protected def getPartitionsNumber: Int = 3
+
+  def storePartitionWithOffset(topic: String, partition: Int, offset: Long)(implicit ec: ExecutionContext): Future[Done]
+
+  def loadPartitionWithOffsetMap(topic: String)(implicit ec: ExecutionContext): Future[Map[Int, Long]]
+
+  protected def initPartitionData(topic: String)(implicit ec: ExecutionContext): Future[Map[Int, Long]]
+
+  final def getPartitionWithOffsetMap(topic: String)(implicit ec: ExecutionContext): Future[Map[Int, Long]] =
+    loadPartitionWithOffsetMap(topic).flatMap {
+      case map if map.isEmpty => initPartitionData(topic)
+      case map                => Future.successful(map)
+    }
+}

--- a/popu-tracker/src/main/scala/infrastructure/db/ecst/OffsetStore.scala
+++ b/popu-tracker/src/main/scala/infrastructure/db/ecst/OffsetStore.scala
@@ -1,0 +1,32 @@
+package infrastructure.db.ecst
+
+import akka.Done
+
+import scala.concurrent.{ExecutionContext, Future}
+
+abstract class OffsetStore[K, V, R, Passthrough](offsetProcessing: IOffsetProcessing)(implicit ec: ExecutionContext) {
+
+  protected def businessLogic(key: K, value: V): (Future[R], Passthrough)
+
+  def businessLogicAndStoreOffset(
+                                   key: K,
+                                   value: V,
+                                   topic: String,
+                                   partition: Int,
+                                   offset: Long): (Future[R], Passthrough) = {
+    val (future, passthrough) = businessLogic(key, value)
+    (for {
+      result <- future
+      _ <- offsetProcessing.storePartitionWithOffset(topic, partition, offset)
+    } yield result) -> passthrough
+  }
+
+  final def storePartitionWithOffset(topic: String, partition: Int, offset: Long): Future[Done] =
+    offsetProcessing.storePartitionWithOffset(topic, partition, offset)
+
+  final def loadPartitionWithOffsetMap(topic: String): Future[Map[Int, Long]] =
+    offsetProcessing.loadPartitionWithOffsetMap(topic)
+
+  final def getPartitionWithOffsetMap(topic: String): Future[Map[Int, Long]] =
+    offsetProcessing.getPartitionWithOffsetMap(topic)
+}

--- a/popu-tracker/src/main/scala/infrastructure/db/tracker/TaskColumns.scala
+++ b/popu-tracker/src/main/scala/infrastructure/db/tracker/TaskColumns.scala
@@ -1,0 +1,5 @@
+package infrastructure.db.tracker
+
+trait TaskColumns {
+
+}

--- a/popu-tracker/src/main/scala/infrastructure/db/tracker/TaskRepository.scala
+++ b/popu-tracker/src/main/scala/infrastructure/db/tracker/TaskRepository.scala
@@ -1,0 +1,15 @@
+package infrastructure.db.tracker
+
+import domain.Task
+import domain.value_object.AccountId
+
+import scala.concurrent.Future
+
+// todo impl
+trait TaskRepository {
+  def insert(task: Task): Future[Int]
+
+  def assign: Future[Int]
+
+  def findAllFor(accountId: AccountId): Future[Seq[Task]]
+}

--- a/popu-tracker/src/main/scala/infrastructure/kafka/AccountEcstConsumer.scala
+++ b/popu-tracker/src/main/scala/infrastructure/kafka/AccountEcstConsumer.scala
@@ -1,0 +1,29 @@
+package infrastructure.kafka
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.kafka.scaladsl.Consumer.DrainingControl
+import domain.value_object.{Account, AccountId}
+import infrastructure.db.ecst.EcstOffsetStore
+import org.apache.kafka.clients.consumer.ConsumerConfig
+
+import scala.concurrent.Future
+
+class AccountEcstConsumer(
+                           topic: String,
+                           consumerConfig: ConsumerConfig,
+                           store: EcstOffsetStore[AccountId, Account]
+                         )(implicit sys: ActorSystem) {
+  def read(): Future[DrainingControl[Done]] =
+    EcstSubscriber.receiveMessages(
+      topic,
+      store,
+      consumerConfig,
+      1
+    )
+}
+
+object AccountEcstConsumer {
+  def apply(topic: String, consumerConfig: ConsumerConfig, store: EcstOffsetStore[AccountId, Account])(implicit sys: ActorSystem) =
+    new AccountEcstConsumer(topic, consumerConfig, store)
+}

--- a/popu-tracker/src/main/scala/infrastructure/kafka/EcstSubscriber.scala
+++ b/popu-tracker/src/main/scala/infrastructure/kafka/EcstSubscriber.scala
@@ -1,0 +1,32 @@
+package infrastructure.kafka
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.kafka.ConsumerSettings
+import akka.kafka.scaladsl.Consumer.DrainingControl
+import com.typesafe.config.Config
+import domain.value_object.{BaseEntity, EntityId}
+import infrastructure.db.ecst.EcstOffsetStore
+import org.apache.kafka.common.serialization.{StringDeserializer, UUIDDeserializer}
+
+import scala.concurrent.Future
+
+object EcstSubscriber {
+  /** Получить сообщения из топика */
+  def receiveMessages[
+    Id <: EntityId,
+    Entity <: BaseEntity[Id],
+  ](
+     topicName: String,
+     offsetStore: EcstOffsetStore[Id, Entity],
+     consumerConf: Config,
+     requiredProtocolVersion: Int
+   )(implicit
+     actorSystem: ActorSystem): Future[DrainingControl[Done]] =
+    receive(
+      topicName,
+      offsetStore,
+      ConsumerSettings(consumerConf, UUIDDeserializer, StringDeserializer),
+      requiredProtocolVersion
+    )
+}

--- a/popu-tracker/src/main/scala/infrastructure/kafka/EventType.scala
+++ b/popu-tracker/src/main/scala/infrastructure/kafka/EventType.scala
@@ -1,0 +1,21 @@
+package infrastructure.kafka
+
+sealed trait EventType
+
+case object Create extends EventType {
+  override def toString(): String = EventType.Create
+}
+
+case object Update extends EventType {
+  override def toString(): String = EventType.Update
+}
+
+case object Delete extends EventType {
+  override def toString(): String = EventType.Delete
+}
+
+object EventType {
+  val Create: String = "create"
+  val Update: String = "update"
+  val Delete: String = "delete"
+}

--- a/popu-tracker/src/main/scala/infrastructure/kafka/IEntityRecord.scala
+++ b/popu-tracker/src/main/scala/infrastructure/kafka/IEntityRecord.scala
@@ -1,0 +1,170 @@
+package infrastructure.kafka
+
+import domain.value_object.{BaseEntity, EntityId}
+import infrastructure.kafka.EntityRecord.{EventTypeProperty, FieldMaskProperty, ProtocolVersionProperty}
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.header.internals.RecordHeader
+
+import java.util.UUID
+
+sealed trait IEntityRecord[Id <: EntityId, Entity <: BaseEntity[Id]] {
+
+  /** Тип события */
+  def eventType: EventType
+
+  /** Заголовки записи сообщения в Kafka */
+  def getHeaders: List[RecordHeader] = List(new RecordHeader(EventTypeProperty, eventType.toString.getBytes()))
+
+  /** Получить запись сообщения в Kafka */
+  def getRecord(topic: String): ProducerRecord[UUID, String]
+
+  /** Идентификатор сущности */
+  def getEntityId: Id
+
+  /** Основные параметры записи */
+  protected def mainParams: List[(String, String)] = List("headers" -> getHeaders.toString())
+
+  /** Текстовое представление записи */
+  def show: String = s"${getClass.getName}${mainParams.map { case (k, v) => s"$k=$v" }.mkString("(", ", ", ")")}"
+}
+
+/** Наличие в записи версии протокола */
+trait IProtocolVersion {
+  def protocolVersion: Int
+
+  protected def versionHeader: RecordHeader =
+    new RecordHeader(ProtocolVersionProperty, protocolVersion.toString.getBytes())
+}
+
+/**
+ * Запись в Kafka о создании сущности
+ *
+ * @param entity          созданная сущность
+ * @param protocolVersion версия протокола
+ * @tparam Id     тип идентификатора сущности, распространяемой через Kafka
+ * @tparam Entity тип сущности, распространяемой через Kafka
+ */
+final case class EntityCreatingRecord[Id <: EntityId, Entity <: BaseEntity[Id]](entity: String, protocolVersion: Int)
+  extends IEntityRecord[Id, Entity]
+    with IProtocolVersion {
+
+  val eventType: EventType = Create
+
+  override def getHeaders: List[RecordHeader] = versionHeader :: super.getHeaders
+
+  def getEntity: String = entity.toString
+
+  def getRecord(topic: String): ProducerRecord[UUID, String] = {
+    val record = new ProducerRecord(topic, getEntityId.id, getEntity)
+    getHeaders.foreach(record.headers().add)
+    record
+  }
+
+  def getEntityId: Id = entity.entityId
+
+  override protected def mainParams: List[(String, String)] =
+    ("entity", entity.toString) :: ("protocolVersion", protocolVersion.toString) :: super.mainParams
+}
+
+/**
+ * Запись в Kafka об обновлении сущности
+ *
+ * @param entityId        идентификатор обновляемой сущности
+ * @param entity          обновленная сущность
+ * @param protocolVersion версия протокола
+ * @tparam Id     тип идентификатора сущности, распространяемой через Kafka
+ * @tparam Entity тип сущности, распространяемой через Kafka
+ */
+final case class EntityUpdatingRecord[Id <: EntityId, Entity <: BaseEntity[Id]](
+                                                                                 entityId: Id,
+                                                                                 entity: Entity,
+                                                                                 protocolVersion: Int)
+  extends IEntityRecord[Id, Entity]
+    with IProtocolVersion {
+
+  val eventType: EventType = Update
+
+  override def getHeaders: List[RecordHeader] = versionHeader :: super.getHeaders
+
+  def getEntity: String = entity.toString
+
+  def getRecord(topic: String): ProducerRecord[UUID, String] = {
+    val record = new ProducerRecord(topic, getEntityId.id, getEntity)
+    getHeaders.foreach(record.headers().add)
+    record
+  }
+
+  def getEntityId: Id = entity.entityId
+
+  override protected def mainParams: List[(String, String)] =
+    ("entity", entity.toString) :: ("protocolVersion", protocolVersion.toString) :: super.mainParams
+}
+
+/**
+ * Запись в Kafka об удалении сущности
+ *
+ * @param entityId идентификатор удаляемой сущности
+ * @tparam Id     тип идентификатора сущности, распространяемой через Kafka
+ * @tparam Entity тип сущности, распространяемой через Kafka
+ */
+final case class EntityDeletingRecord[Id <: EntityId, Entity <: BaseEntity[Id]](entityId: Id)
+  extends IEntityRecord[Id, Entity] {
+
+  val eventType: EventType = Delete
+
+  def getRecord(topic: String): ProducerRecord[UUID, String] = {
+    val record = new ProducerRecord(topic, entityId.id, null.asInstanceOf[String])
+    getHeaders.foreach(record.headers().add)
+    record
+  }
+
+  def getEntityId: Id = entityId
+
+  override protected def mainParams: List[(String, String)] = ("entityId", entityId.toString) :: super.mainParams
+}
+
+object EntityRecord {
+  val EventTypeProperty: String = "eventType"
+
+  val ProtocolVersionProperty: String = "protocolVersion"
+
+  val FieldMaskProperty: String = "fieldMask"
+
+  def getProtocolVersion(record: ConsumerRecord[UUID, String]): Option[Int] =
+    record.headers().toArray.collectFirst {
+      case header if header.key() == ProtocolVersionProperty => new String(header.value()).toInt
+    }
+
+  def from[Id <: EntityId, Entity <: BaseEntity[Id]](
+                                                      record: ConsumerRecord[UUID, String],
+                                                      requiredProtocolVersion: Int
+                                                    ): Option[IEntityRecord[Id, Entity]] = {
+    val headers = record.headers().toArray
+
+    def protocolVersion: Int = getProtocolVersion(record).getOrElse(
+      throw new UnsupportedOperationException("Полученное сообщение не содержит информацию о версии протокола")
+    )
+
+    headers.find(_.key() == EventTypeProperty).map(h => new String(h.value())) match {
+      case Some(EventType.Create) =>
+        val version = protocolVersion
+        if (version == requiredProtocolVersion) {
+          val entity = record.value()
+          Some(EntityCreatingRecord[Id, Entity](entity, version))
+        } else
+          None
+      case Some(EventType.Update) =>
+        val version = protocolVersion
+        if (version == requiredProtocolVersion) {
+          val entity = record.value()
+          Some(EntityUpdatingRecord[Id, Entity](record.key(), entity, version))
+        } else
+          None
+      case Some(EventType.Delete) =>
+        Some(EntityDeletingRecord[Id, Entity](record.key()))
+      case _ =>
+        throw new UnsupportedOperationException("Полученное сообщение не содержит информацию о типе события")
+    }
+  }
+}

--- a/popu-tracker/src/main/scala/infrastructure/kafka/SubscriberApi.scala
+++ b/popu-tracker/src/main/scala/infrastructure/kafka/SubscriberApi.scala
@@ -1,0 +1,63 @@
+package infrastructure.kafka
+
+import akka.Done
+import akka.actor.typed.ActorSystem
+import akka.kafka.{ConsumerSettings, Subscriptions}
+import akka.kafka.scaladsl.Consumer
+import akka.kafka.scaladsl.Consumer.DrainingControl
+import akka.stream.scaladsl
+import akka.stream.scaladsl.Sink
+import domain.value_object.{BaseEntity, EntityId}
+import infrastructure.db.ecst.EcstOffsetStore
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.TopicPartition
+
+import java.util.UUID
+import scala.concurrent.{ExecutionContextExecutor, Future}
+import scala.io.Source
+
+/** Интерфейс подписчика на топик в Kafka для получения данных из другого сервиса */
+trait SubscriberApi {
+
+  /** Получить сообщения из топика */
+  protected[ecst] def receiveWithDeserializing[Id <: EntityId, Entity <: BaseEntity[Id]](
+                                                                                          topicName: String,
+                                                                                          offsetStore: EcstOffsetStore[Id, Entity],
+                                                                                          consumerSettings: ConsumerSettings[UUID, String],
+                                                                                          requiredProtocolVersion: Int)(implicit
+                                                                                                                        actorSystem: ActorSystem[_]
+                                                                                        ): Future[DrainingControl[Done]] = {
+    implicit val ec: ExecutionContextExecutor = actorSystem.executionContext
+    offsetStore.getPartitionWithOffsetMap(topicName).map { partitionWithOffsetMap =>
+      createConsumer(topicName, consumerSettings, partitionWithOffsetMap)
+        .mapAsync(1) { record =>
+          EntityRecord.from(record, requiredProtocolVersion) match {
+            case Some(entity) =>
+              offsetStore
+                .businessLogicAndStoreOffset(record.key(), entity, topicName, record.partition(), record.offset())
+                ._1
+            case None =>
+              offsetStore.storePartitionWithOffset(topicName, record.partition(), record.offset())
+          }
+        }
+        .toMat(Sink.ignore)(DrainingControl.apply)
+        .run()
+    }
+  }
+
+  /** Консьюмер сообщений из топика с учетом переданных данных о партициях и офсетах */
+  private def createConsumer(
+                              topicName: String,
+                              consumerSettings: ConsumerSettings[UUID, String],
+                              partitionWithOffsetMap: Map[Int, Long]
+                            ): scaladsl.Source[ConsumerRecord[UUID, String], Consumer.Control] =
+    Consumer
+      .plainSource(
+        consumerSettings,
+        Subscriptions.assignmentWithOffset(
+          partitionWithOffsetMap.map { case (partition, offset) =>
+            new TopicPartition(topicName, partition) -> offset
+          }
+        )
+      )
+}

--- a/popu-tracker/src/main/scala/infrastructure/rest/RestEndpoint.scala
+++ b/popu-tracker/src/main/scala/infrastructure/rest/RestEndpoint.scala
@@ -1,0 +1,64 @@
+package infrastructure.rest
+
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.{ActorSystem, Behavior, PostStop}
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.Http.ServerBinding
+import akka.http.scaladsl.server.Route
+
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+object RestEndpoint {
+  sealed trait Message
+
+  private final case class Started(binding: ServerBinding) extends Message
+  private final case class StartFailed(cause: Throwable) extends Message
+  case object Stop extends Message
+
+  def apply(
+    host: String,
+    port: Int,
+    routes: Route
+  ): Behavior[Message] =
+    Behaviors.setup[Message]{ implicit context =>
+      implicit val system: ActorSystem[_] = context.system
+
+      val bindingFuture: Future[Http.ServerBinding] =
+        Http().newServerAt(host, port)
+          .bind(routes)
+
+      context.pipeToSelf(bindingFuture) {
+        case Success(binding) => Started(binding)
+        case Failure(exception) => StartFailed(exception)
+      }
+
+      def running(binding: ServerBinding): Behavior[Message] =
+        Behaviors.receiveMessagePartial[Message] {
+          case Stop =>
+            context.log.info("Stopping REST Endpoint at http://{}", binding.localAddress)
+            Behaviors.stopped
+        }.receiveSignal {
+          case (_, PostStop) =>
+            binding.unbind()
+            Behaviors.same
+        }
+
+      def starting(wasStopped: Boolean): Behaviors.Receive[Message] =
+        Behaviors.receiveMessage[Message] {
+          case StartFailed(cause) =>
+            throw new RuntimeException("Exception at startup REST Endpoint", cause)
+          case Started(binding) =>
+            context.log.info("REST Endpoint started at http://{}", binding.localAddress)
+            if (wasStopped) {
+              context.self ! Stop
+            }
+            running(binding)
+          case Stop =>
+            starting(wasStopped = true)
+        }
+
+      starting(wasStopped = false)
+    }
+  }
+

--- a/popu-tracker/src/main/scala/infrastructure/rest/Routes.scala
+++ b/popu-tracker/src/main/scala/infrastructure/rest/Routes.scala
@@ -1,0 +1,76 @@
+package infrastructure.rest
+
+import akka.actor.typed.ActorSystem
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import akka.http.scaladsl.model.HttpMethods._
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.{ExceptionHandler, Route}
+import akka.util.Timeout
+import ch.megard.akka.http.cors.scaladsl.CorsDirectives.cors
+import ch.megard.akka.http.cors.scaladsl.settings.CorsSettings
+import domain.Task
+import domain.value_object.AccountId
+import infrastructure.rest.utils.JWTUtils
+import org.postgresql.util.PSQLException
+import service.TrackerService
+import spray.json.DefaultJsonProtocol._
+import spray.json.DeserializationException
+
+import scala.concurrent.ExecutionContextExecutor
+import scala.util.{Failure, Success}
+
+class Routes(trackerService: TrackerService
+            )(implicit system: ActorSystem[_], timeout: Timeout, jwtUtils: JWTUtils) {
+  implicit val ec: ExecutionContextExecutor = system.executionContext
+
+  private val corsSettings: CorsSettings = CorsSettings.defaultSettings.withAllowedMethods(Seq(GET, PATCH, POST, OPTIONS, DELETE))
+
+  private def createTask: Route = (post & entity(as[Task])) { newTask =>
+    complete(StatusCodes.Created, trackerService.create(newTask))
+  }
+
+  private def assignTasks: Route = (path("assign")) {
+    pathEndOrSingleSlash {
+      complete(StatusCodes.OK, trackerService.assign)
+    }
+  }
+
+  private def list(implicit accountId: AccountId): Route = pathEndOrSingleSlash {
+    complete(StatusCodes.OK, trackerService.list)
+  }
+
+  private def trackerRoutes(implicit accountId: AccountId): Route = createTask ~ get { assignTasks ~ list }
+
+  val routes: Route = cors(corsSettings) {
+    Route.seal(
+      pathPrefix("api" / "popu-tracker" / "v1") {
+        cookie("token") { cookie =>
+          jwtUtils.verifyJWT(cookie.value) match {
+            case Success(value) =>
+              implicit val accId: AccountId = AccountId.fromString(value.getClaim("accountId").asString())
+              trackerRoutes
+            case Failure(_) =>
+              complete(StatusCodes.Unauthorized, "Token validation failed")
+          }
+        }
+      }
+    )
+  }
+
+  implicit def exceptionHandler: ExceptionHandler =
+    ExceptionHandler {
+      case ex: DeserializationException =>
+        complete(StatusCodes.BadRequest, ex.msg)
+      case ex: IllegalArgumentException =>
+        complete(StatusCodes.BadRequest, ex.getMessage)
+      case ex: PSQLException =>
+        complete(StatusCodes.BadRequest, ex.getMessage)
+    }
+}
+
+object Routes {
+  def apply(trackerService: TrackerService)(
+    implicit system: ActorSystem[_], timeout: Timeout, jwtUtils: JWTUtils) = new Routes(trackerService)
+}
+

--- a/popu-tracker/src/main/scala/infrastructure/rest/package.scala
+++ b/popu-tracker/src/main/scala/infrastructure/rest/package.scala
@@ -1,0 +1,37 @@
+package infrastructure
+
+import spray.json.{DeserializationException, JsString, JsValue, JsonFormat, deserializationError}
+
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+
+package object rest {
+  implicit object InstantFormat extends JsonFormat[Instant] {
+
+    private val dtf = DateTimeFormatter.ISO_OFFSET_DATE_TIME
+
+    override def read(jsv: JsValue): Instant = jsv match {
+      case JsString(s) if s.endsWith("Z") => Instant.parse(s)
+
+      // Note that Zalando JSON guidelines do NOT allow non-UTC offsets in stored data.
+      case JsString(s) =>
+        Instant.from(dtf.parse(s))
+      case _ =>
+        deserializationError(s"Unknown Instant (ISO 8601 with UTC time zone expected): $jsv")
+    }
+
+    override def write(obj: Instant): JsValue = JsString(obj.toString)
+  }
+
+  implicit object IdJsonFormat extends JsonFormat[UUID] {
+    def write(id: UUID): JsString = JsString(id.toString)
+
+    def read(value: JsValue): UUID = {
+      value match {
+        case JsString(uuid) => UUID.fromString(uuid)
+        case _ => throw DeserializationException("Expected hexadecimal UUID string")
+      }
+    }
+  }
+}

--- a/popu-tracker/src/main/scala/infrastructure/rest/utils/JWTUtils.scala
+++ b/popu-tracker/src/main/scala/infrastructure/rest/utils/JWTUtils.scala
@@ -1,0 +1,51 @@
+package infrastructure.rest.utils
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import com.auth0.jwt.interfaces.DecodedJWT
+import com.typesafe.config.Config
+
+import java.security.KeyFactory
+import java.security.interfaces.{RSAPrivateKey, RSAPublicKey}
+import java.security.spec.{PKCS8EncodedKeySpec, X509EncodedKeySpec}
+import java.util.Base64
+import scala.util.Try
+
+/**
+ * Утилиты для верификации JWT
+ */
+class JWTUtils(jwtConfig: Config) {
+  /** Алгоритм подписания и верификации */
+  private lazy val algorithm: Algorithm = {
+    val factory = KeyFactory.getInstance("RSA")
+    val publicKeySpec = new X509EncodedKeySpec(Base64.getDecoder.decode(jwtConfig.getString("public-key").getBytes))
+    val privateKeySpec = new PKCS8EncodedKeySpec(Base64.getDecoder.decode(jwtConfig.getString("private-key").getBytes))
+
+    Algorithm.RSA256(factory.generatePublic(publicKeySpec).asInstanceOf[RSAPublicKey], factory.generatePrivate(privateKeySpec).asInstanceOf[RSAPrivateKey])
+  }
+
+  /**
+   * Верификация JWT
+   *
+   * @param token JWT
+   * @return Валидный ли токен?
+   */
+  def verifyJWT(token: String): Try[DecodedJWT] = {
+    val verifier = JWT.require(algorithm).build()
+    Try(verifier.verify(token))
+  }
+
+  /**
+   * Создание подписанного JWT
+   *
+   * @param claims Полезная нагрузка токена
+   * @return JWT
+   */
+  def createSignedJWT(claims: (String, String)*): String = {
+    val jwtBuilder = JWT.create()
+    claims.foreach { case (name, value) =>
+      jwtBuilder.withClaim(name, value)
+    }
+    jwtBuilder.sign(algorithm)
+  }
+}

--- a/popu-tracker/src/main/scala/service/TrackerService.scala
+++ b/popu-tracker/src/main/scala/service/TrackerService.scala
@@ -1,0 +1,15 @@
+package service
+
+import akka.Done
+import domain.Task
+import domain.value_object.AccountId
+
+import scala.concurrent.Future
+
+trait TrackerService {
+  def create(task: Task): Future[Done]
+
+  def assign: Future[Done]
+
+  def list(implicit accId: AccountId): Future[Seq[Task]]
+}

--- a/popu-tracker/src/main/scala/service/TrackerServiceImpl.scala
+++ b/popu-tracker/src/main/scala/service/TrackerServiceImpl.scala
@@ -1,0 +1,20 @@
+package service
+import akka.Done
+import domain.Task
+import domain.value_object.AccountId
+import infrastructure.db.tracker.TaskRepository
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class TrackerServiceImpl(taskRepository: TaskRepository)(implicit ec: ExecutionContext) extends TrackerService {
+
+  override def create(task: Task): Future[Done] = taskRepository.insert(task).map(_ => Done)
+
+  override def assign: Future[Done] = taskRepository.assign.map(_ => Done)
+
+  override def list(implicit accId: AccountId): Future[Seq[Task]] = taskRepository.findAllFor(accId)
+}
+
+object TrackerServiceImpl {
+  def apply(trackerRepository: TaskRepository)(implicit ec: ExecutionContext) = new TrackerServiceImpl(trackerRepository)
+}

--- a/popug-acc/Dockerfile
+++ b/popug-acc/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:21-slim
+WORKDIR /app
+COPY popug-acc/target/scala-2.13/popug-acc-*.jar ./app.jar
+ENTRYPOINT ["java"]

--- a/popug-acc/docker-compose.yaml
+++ b/popug-acc/docker-compose.yaml
@@ -1,0 +1,25 @@
+version: "3.3"
+
+services:
+  popug-acc:
+    build: .
+    image: popug-acc:latest
+    container_name: popug-acc
+    depends_on:
+      keycloak:
+        condition: service_healthy
+  keycloak:
+    image: quay.io/keycloak/keycloak:23.0.7
+    environment:
+      - KEYCLOAK_ADMIN=admin
+      - KEYCLOAK_ADMIN_PASSWORD=admin
+      - KC_HEALTH_ENABLED=true
+    healthcheck:
+      test: [ "CMD-SHELL", "exec 3<>/dev/tcp/127.0.0.1/8080;echo -e \"GET /health/ready HTTP/1.1\r\nhost: http://localhost\r\nConnection: close\r\n\r\n\" >&3;grep \"HTTP/1.1 200 OK\" <&3" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    ports:
+      - "18080:8080"
+    command:
+      - start-dev

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,6 +14,7 @@ object Dependencies {
   val CorsHandlerVersion = "1.2.0"
   val SwaggerVersion = "2.11.0"
   val PureConfigVersion = "0.17.5"
+  val JwtVersion = "4.4.0"
 
   // rest
   val akkaHttp = "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion
@@ -46,6 +47,9 @@ object Dependencies {
   // hocon config mapping
   val pureConfig = "com.github.pureconfig" %% "pureconfig" % PureConfigVersion
 
+  val jwt = "com.auth0" % "java-jwt" % JwtVersion
+
+
   val commonDependencies: Seq[ModuleID] = Seq(
       akkaHttp
     , sprayJson
@@ -62,5 +66,6 @@ object Dependencies {
     , slickHikariCP
     , postgresqlJdbc
     , pureConfig
+    , jwt
   )
 }


### PR DESCRIPTION
сервис аутентификации запускается из docker-compose.yaml в модуле popug-acc. 
логика аутентификации/авторизации реализуется на стороне keycloak, чей инстанс запускается из компоуза и доступен по  адресу http://localhost:18080.
в kc из-под admin/admin настраивается realm, добавляются роли, конфигурируется клиент, в котором прописываются редиректы на соответствующие url в зависимости от роли в случае успешной авторизации.
добавлен плагин, стримящий события из kc в kafka.
по факту, не успел написать консюмер событий аккаунта по ecst на стороне трекера, нужно чуть больше времени.